### PR TITLE
Fix typo in shortDescription field

### DIFF
--- a/box.json
+++ b/box.json
@@ -11,7 +11,7 @@
 	},
 	"bugs": "https://ortussolutions.atlassian.net/browse/BLMODULES",
 	"slug": "bx-ui-compat",
-	"shortDescription": "CMFL Compatibility UI components module for BoxLang",
+	"shortDescription": "CFML Compatibility UI components module for BoxLang",
 	"type": "boxlang-modules",
 	"keywords": ["boxlang"],
 	"boxlang": {


### PR DESCRIPTION
This shortDescription value is indeed shown if one views this module in the forgebox list of modules (such as currently at https://forgebox.io/type/boxlang-modules/popular/page/2). Curiously, I don't see it showing up on the module page itself (https://forgebox.io/view/bx-ui-compat), so perhaps the shortDescription is never used on that page. 

And that could be why it was not readily noticed by anyone else yet. I'll leave you guys to ponder if perhaps that shortDescription field may have value being shown on the module page itself. :-)

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira/Github Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/ortus-boxlang/bx-ui-compat/issues

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
